### PR TITLE
🏷️ Navbar Click Event 이슈 수정

### DIFF
--- a/components/navbar/NavTab.tsx
+++ b/components/navbar/NavTab.tsx
@@ -10,6 +10,10 @@ const NavTab = ({ menu }: NavTabProps) => {
     <Link
       href={menu.path}
       className="md:text-xl sm:text-base hover:text-gray-300 transition-colors hover:border-b"
+      onClick={(e) => {
+        e.preventDefault();
+        window.location.href = menu.path;
+      }}
     >
       {menu.title}
     </Link>


### PR DESCRIPTION
## Navbar Click Event 이슈 수정
- 이슈 : Navbar 를 클릭했을 때 한번 클릭한 경우 Click Event 가 동작 안 하고 두 번 연속으로 클릭해야 Click Event 가 동작하는 이슈

- 원인 : `handleClickOutside` 와 Click Event 가 겹쳐서 해당 현상 발생